### PR TITLE
as_subselect_rs new resultset bugfix

### DIFF
--- a/lib/DBIx/Class/ResultSet.pm
+++ b/lib/DBIx/Class/ResultSet.pm
@@ -3382,7 +3382,8 @@ sub as_subselect_rs {
   my $attrs = $self->_resolved_attrs;
 
   my $fresh_rs = (ref $self)->new (
-    $self->result_source
+    $self->result_source,
+    {}
   );
 
   # these pieces will be locked in the subquery


### PR DESCRIPTION
When using ->pager->count on complicated resultset this error pops up:
`
Single parameters to new() must be a HASH ref at /usr/lib64/perl5/site_perl/5.12.3/x86_64-linux/Moose/Object.pm line 30
        Moose::Object::BUILDARGS('PODirect::Schema::ResultSet::user', 'DBIx::Class::ResultSource::Table=HASH(0x9d5e0f0)') called at /usr/lib64/perl5/site_perl/5.12.3/MooseX/NonMoose/Meta/Role/Class.pm line 154
        MySchema::Schema::ResultSet::user::new('PODirect::Schema::ResultSet::user', 'DBIx::Class::ResultSource::Table=HASH(0x9d5e0f0)') called at /usr/lib64/perl5/site_perl/5.12.3/DBIx/Class/ResultSet.pm line 3389
        DBIx::Class::ResultSet::as_subselect_rs('PODirect::Schema::ResultSet::user=HASH(0x7f32b0acac30)') called at /usr/lib64/perl5/site_perl/5.12.3/DBIx/Class/ResultSet.pm line 1766
        DBIx::Class::ResultSet::_count_subq_rs('PODirect::Schema::ResultSet::user=HASH(0x7f32b0abf518)', 'HASH(0x7f32b0acc820)') called at /usr/lib64/perl5/site_perl/5.12.3/DBIx/Class/ResultSet.pm line 1604                                                                                                                                                
        DBIx::Class::ResultSet::count('PODirect::Schema::ResultSet::user=HASH(0x7f32b0abf518)') called at /usr/lib64/perl5/site_perl/5.12.3/DBIx/Class/ResultSet.pm line 2536  
        DBIx::Class::ResultSet::__ANON__ at /usr/lib64/perl5/site_perl/5.12.3/DBIx/Class/ResultSet/Pager.pm line 15                                                            
        DBIx::Class::ResultSet::Pager::_total_entries_accessor('DBIx::Class::ResultSet::Pager=HASH(0x7f32b0acc178)') called at /usr/lib64/perl5/vendor_perl/5.12.3/Data/Page.pm line 50                                                                                                                                                                       
        Data::Page::total_entries('DBIx::Class::ResultSet::Pager=HASH(0x7f32b0acc178)') called at test.pl line 85
`

Sample code:
`
my $s = $ex->search_rs({
       "category.category" => 'test'
}, {
          'page' => 1,
          'rows' => 10,
          'prefetch' => [
                          {
                            'table1' => [
                                                     {
                                                       'table2' => []
                                                     }
                                                   ]
                          }
                        ],
});
`

This small fix resolves the problem.
